### PR TITLE
Pylintify code

### DIFF
--- a/dataql/exceptions.py
+++ b/dataql/exceptions.py
@@ -5,6 +5,9 @@ may be defined in sub modules inherit from..
 
 """
 
-class DataQLException(Exception):
+from abc import ABCMeta
+
+
+class DataQLException(Exception, metaclass=ABCMeta):
     """Base for exceptions raised by dataql code."""
     pass

--- a/dataql/parsers/base.py
+++ b/dataql/parsers/base.py
@@ -264,7 +264,7 @@ class BaseParser(NodeVisitor, metaclass=RuleDecoratorMeta):
             raise VisitationError(exc, exc_class, node).with_traceback(tb)
 
     @rule('~"[_A-Z][_A-Z0-9]*"i')
-    def visit_ident(self, node, children):
+    def visit_ident(self, node, _):
         """Return a valid python identifier.
 
         It may be used for a resource name, a filter...
@@ -272,7 +272,7 @@ class BaseParser(NodeVisitor, metaclass=RuleDecoratorMeta):
         Arguments
         ---------
         node : parsimonious.nodes.Node.
-        children : list, unused
+        _ (children) : list, unused
 
         Result
         ------
@@ -305,13 +305,13 @@ class BaseParser(NodeVisitor, metaclass=RuleDecoratorMeta):
         return node.text
 
     @rule('COL_OR_EQ')
-    def visit_oper(self, node, children):
+    def visit_oper(self, node, _):
         """Return an operator as a string. Currently only "=" and ":" (both synonyms)
 
         Arguments
         ---------
         node : parsimonious.nodes.Node.
-        children : list, unused
+        _ (children) : list, unused
 
         Result
         ------
@@ -334,12 +334,12 @@ class BaseParser(NodeVisitor, metaclass=RuleDecoratorMeta):
         return oper
 
     @rule('STR / NB / NULL / FALSE / TRUE')
-    def visit_value(self, node, children):
+    def visit_value(self, _, children):
         """Return a value, which is a string, a number, a null/false/true like value.
 
         Arguments
         ---------
-        node : parsimonious.nodes.Node.
+        _ (node) : parsimonious.nodes.Node.
         children : list
             - 0: the value to return
 
@@ -368,7 +368,7 @@ class BaseParser(NodeVisitor, metaclass=RuleDecoratorMeta):
         return children[0]
 
     @rule(r'~"([\'\"])(?:[^\\1\\\\]|\\\\.)*?\\1"')
-    def visit_str(self, node, children):
+    def visit_str(self, node, _):
         """Regex rule for quoted string allowing escaped quotes inside.
 
         Arguments
@@ -410,8 +410,8 @@ class BaseParser(NodeVisitor, metaclass=RuleDecoratorMeta):
     # regex  to unquote single quote characters
     visit_str.re_single_backslash = re.compile(r'(?<!\\)\\')
 
-    @rule('~"[-+]?\d*\.?\d+([eE][-+]?\d+)?"')
-    def visit_nb(self, node, children):
+    @rule(r'~"[-+]?\d*\.?\d+([eE][-+]?\d+)?"')
+    def visit_nb(self, node, _):
         """Return a int of float from the given number.
 
         Also work with scientific notation like 1e+50.
@@ -450,13 +450,13 @@ class BaseParser(NodeVisitor, metaclass=RuleDecoratorMeta):
         return self.convert_nb(node.text)
 
     @rule('~"(?:null|nil|none)"i')
-    def visit_null(self, node, children):
+    def visit_null(self, *_):
         """Return ``None`` for the string "null", "none", or "nil" (case insensitive)
 
         Arguments
         ---------
-        node : parsimonious.nodes.Node.
-        children : list, unused
+        _[0] (node) : parsimonious.nodes.Node.
+        _[1] (children) : list, unused
 
         Returns
         -------
@@ -489,13 +489,13 @@ class BaseParser(NodeVisitor, metaclass=RuleDecoratorMeta):
         return None
 
     @rule('~"(?:false)"i')
-    def visit_false(self, node, children):
+    def visit_false(self, *_):
         """Return ``False`` for the string "false" (case insensitive)
 
         Arguments
         ---------
-        node : parsimonious.nodes.Node.
-        children : list, unused
+        _[0] (node) : parsimonious.nodes.Node.
+        _[1] (children) : list, unused
 
         Returns
         -------
@@ -516,13 +516,13 @@ class BaseParser(NodeVisitor, metaclass=RuleDecoratorMeta):
         return False
 
     @rule('~"(?:true)"i')
-    def visit_true(self, node, children):
+    def visit_true(self, *_):
         """Return ``True`` for the string "true" (case insensitive)
 
         Arguments
         ---------
-        node : parsimonious.nodes.Node.
-        children : list, unused
+        _[0] (node) : parsimonious.nodes.Node.
+        _[1] (children) : list, unused
 
         Returns
         -------

--- a/dataql/parsers/generic.py
+++ b/dataql/parsers/generic.py
@@ -39,12 +39,12 @@ class DataQLParser(FiltersParserMixin, BaseParser):
     default_rule = 'ROOT'
 
     @rule('WS NAMED_RESOURCE WS')
-    def visit_root(self, node, children):
+    def visit_root(self, _, children):
         """The main node holding all the query.
 
         Arguments
         ---------
-        node : parsimonious.nodes.Node.
+        _ (node) : parsimonious.nodes.Node.
         children : list
             - 0: for ``WS`` (whitespace): ``None``.
             - 1: for ``NAMED_RESOURCE``: an instance of a subclass of ``.resources.Resource``.
@@ -91,12 +91,12 @@ class DataQLParser(FiltersParserMixin, BaseParser):
         return resource
 
     @rule('LIST / OBJECT / FIELD')
-    def visit_resource(self, node, children):
+    def visit_resource(self, _, children):
         """A resource in the query, could be a list, an object or a simple field.
 
         Arguments
         ---------
-        node : parsimonious.nodes.Node.
+        _ (node) : parsimonious.nodes.Node.
         children : list
             - 0: an instance of a subclass of ``.resources.Resource``, depending of the type that
               matches the rule.
@@ -128,12 +128,12 @@ class DataQLParser(FiltersParserMixin, BaseParser):
         return children[0]
 
     @rule('OPTIONAL_RESOURCE_NAME RESOURCE')
-    def visit_named_resource(self, node, children):
+    def visit_named_resource(self, _, children):
         """A resource in the query with its optional name.
 
         Arguments
         ---------
-        node : parsimonious.nodes.Node.
+        _ (node) : parsimonious.nodes.Node.
         children : list
             - 0: for ``OPTIONAL_RESOURCE_NAME``: str, the name of the resource, or ``None`` if not
                  set in the query.
@@ -163,12 +163,12 @@ class DataQLParser(FiltersParserMixin, BaseParser):
         return resource
 
     @rule('COM NAMED_RESOURCE')
-    def visit_next_resource(self, node, children):
+    def visit_next_resource(self, _, children):
         """A resource in the query preceded by a coma, to define a resource following an other one.
 
         Arguments
         ---------
-        node : parsimonious.nodes.Node.
+        _ (node) : parsimonious.nodes.Node.
         children : list
             - 0: for ``COM`` (coma): ``None``.
             - 1: for ``NAMED_RESOURCE``: an instance of a subclass of ``.resources.Resource``.
@@ -193,12 +193,12 @@ class DataQLParser(FiltersParserMixin, BaseParser):
         return children[1]
 
     @rule('NEXT_RESOURCE*')
-    def visit_next_resources(self, node, children):
+    def visit_next_resources(self, _, children):
         """A list of resource in the query following the first resource.
 
         Arguments
         ---------
-        node : parsimonious.nodes.Node.
+        _ (node) : parsimonious.nodes.Node.
         children : list
             - 0: for ``NEXT_RESOURCE*``: a list of instances of subclasses of
                 ``.resources.Resource``.
@@ -229,12 +229,12 @@ class DataQLParser(FiltersParserMixin, BaseParser):
         return children
 
     @rule('RESOURCE NEXT_RESOURCES COM?')
-    def visit_content(self, node, children):
+    def visit_content(self, _, children):
         """The content of a resource, composed of a list of resources.
 
         Arguments
         ---------
-        node : parsimonious.nodes.Node.
+        _ (node) : parsimonious.nodes.Node.
         children : list
             - 0: for ``RESOURCE``: first resource, instance of a subclass of
                  ``.resources.Resource``.
@@ -268,7 +268,7 @@ class DataQLParser(FiltersParserMixin, BaseParser):
         return [children[0]] + (children[1] or [])
 
     @rule('IDENT WS COL WS')
-    def visit_resource_name(self, node, children):
+    def visit_resource_name(self, _, children):
         """The name of a resource, to force a name of a resource.
 
         Without it, the resource entry name will be used.
@@ -277,7 +277,7 @@ class DataQLParser(FiltersParserMixin, BaseParser):
 
         Arguments
         ---------
-        node : parsimonious.nodes.Node.
+        _ (node) : parsimonious.nodes.Node.
         children : list
             - 0: for ``IDENT``: string, the name of the resource.
             - 1: for ``COL`` (colon separating the name and its ): ``None``.
@@ -300,7 +300,7 @@ class DataQLParser(FiltersParserMixin, BaseParser):
         return children[0]
 
     @rule('RESOURCE_NAME?')
-    def visit_optional_resource_name(self, node, children):
+    def visit_optional_resource_name(self, _, children):
         """The optional name of a resource, to force a name of a resource if set.
 
         Without it, the resource entry name will be used.
@@ -309,7 +309,7 @@ class DataQLParser(FiltersParserMixin, BaseParser):
 
         Arguments
         ---------
-        node : parsimonious.nodes.Node.
+        _ (node) : parsimonious.nodes.Node.
         children : list
             - 0: for ``RESOURCE_NAME?``: string, the name of the resource.
 
@@ -330,12 +330,12 @@ class DataQLParser(FiltersParserMixin, BaseParser):
         return children[0] if children and children[0] else None
 
     @rule('FILTERS')
-    def visit_field(self, node, children):
+    def visit_field(self, _, children):
         """A simple field.
 
         Arguments
         ---------
-        node : parsimonious.nodes.Node.
+        _ (node) : parsimonious.nodes.Node.
         children : list
             - 0: for ``FILTERS``: list of instances of ``.resources.Field``.
 
@@ -357,7 +357,8 @@ class DataQLParser(FiltersParserMixin, BaseParser):
 
         return self.filters_to_resource(children[0], self.Field)
 
-    def filters_to_resource(self, filters, klass, **kwargs):
+    @staticmethod
+    def filters_to_resource(filters, klass, **kwargs):
         """Helper to create a resource taking its name and args from the first filter.
 
         This remove the first filter from the list of filters
@@ -376,7 +377,7 @@ class DataQLParser(FiltersParserMixin, BaseParser):
 
         return klass(**attrs)
 
-    def visit_subresource(self, klass, node, children):
+    def visit_subresource(self, klass, _, children):
         """Helper to create a List or Object.
 
         The name of the resource is the name of the first filter. And if this first filter doesn't
@@ -385,7 +386,7 @@ class DataQLParser(FiltersParserMixin, BaseParser):
         Arguments
         ---------
         klass: The class for which we want an instance
-        node : parsimonious.nodes.Node.
+        _ (node) : parsimonious.nodes.Node.
         children : list
             - 0: for ``FILTERS``: list of instances of ``.resources.Field``.
             - 1: for ``CUR_O`` or ``BRA_O`` (opening curly/bracket): ``None``.
@@ -410,7 +411,7 @@ class DataQLParser(FiltersParserMixin, BaseParser):
         return self.filters_to_resource(children[0], klass)
 
     @rule('FILTERS CUR_O CONTENT CUR_C')
-    def visit_object(self, node, children):
+    def visit_object(self, _, children):
         """Manage an object, represented by a ``.resources.Object`` instance.
 
         The first filter is removed to fill the name and args of the resource. See
@@ -419,7 +420,7 @@ class DataQLParser(FiltersParserMixin, BaseParser):
 
         Arguments
         ---------
-        node : parsimonious.nodes.Node.
+        _ (node) : parsimonious.nodes.Node.
         children : list
             - 0: for ``FILTERS``: list of instances of ``.resources.Field``.
             - 1: for ``CUR_O`` (opening curly): ``None``.
@@ -440,7 +441,7 @@ class DataQLParser(FiltersParserMixin, BaseParser):
         return self.filters_to_resource(children[0], self.Object, resources=children[2])
 
     @rule('FILTERS BRA_O CONTENT BRA_C')
-    def visit_list(self, node, children):
+    def visit_list(self, _, children):
         """Manage a list, represented by a ``.resources.List`` instance.
 
         The first filter is removed to fill the name and args of the resource. See
@@ -448,7 +449,7 @@ class DataQLParser(FiltersParserMixin, BaseParser):
 
         Arguments
         ---------
-        node : parsimonious.nodes.Node.
+        _ (node) : parsimonious.nodes.Node.
         children : list
             - 0: for ``FILTERS``: list of instances of ``.resources.Field``.
             - 1: for ``BRA_O`` (opening bracket): ``None``.

--- a/dataql/parsers/generic.py
+++ b/dataql/parsers/generic.py
@@ -39,7 +39,7 @@ class DataQLParser(FiltersParserMixin, BaseParser):
     default_rule = 'ROOT'
 
     @rule('WS NAMED_RESOURCE WS')
-    def visit_ROOT(self, node, children):
+    def visit_root(self, node, children):
         """The main node holding all the query.
 
         Arguments
@@ -91,7 +91,7 @@ class DataQLParser(FiltersParserMixin, BaseParser):
         return resource
 
     @rule('LIST / OBJECT / FIELD')
-    def visit_RESOURCE(self, node, children):
+    def visit_resource(self, node, children):
         """A resource in the query, could be a list, an object or a simple field.
 
         Arguments
@@ -128,7 +128,7 @@ class DataQLParser(FiltersParserMixin, BaseParser):
         return children[0]
 
     @rule('OPTIONAL_RESOURCE_NAME RESOURCE')
-    def visit_NAMED_RESOURCE(self, node, children):
+    def visit_named_resource(self, node, children):
         """A resource in the query with its optional name.
 
         Arguments
@@ -163,7 +163,7 @@ class DataQLParser(FiltersParserMixin, BaseParser):
         return resource
 
     @rule('COM NAMED_RESOURCE')
-    def visit_NEXT_RESOURCE(self, node, children):
+    def visit_next_resource(self, node, children):
         """A resource in the query preceded by a coma, to define a resource following an other one.
 
         Arguments
@@ -193,7 +193,7 @@ class DataQLParser(FiltersParserMixin, BaseParser):
         return children[1]
 
     @rule('NEXT_RESOURCE*')
-    def visit_NEXT_RESOURCES(self, node, children):
+    def visit_next_resources(self, node, children):
         """A list of resource in the query following the first resource.
 
         Arguments
@@ -229,7 +229,7 @@ class DataQLParser(FiltersParserMixin, BaseParser):
         return children
 
     @rule('RESOURCE NEXT_RESOURCES COM?')
-    def visit_CONTENT(self, node, children):
+    def visit_content(self, node, children):
         """The content of a resource, composed of a list of resources.
 
         Arguments
@@ -268,7 +268,7 @@ class DataQLParser(FiltersParserMixin, BaseParser):
         return [children[0]] + (children[1] or [])
 
     @rule('IDENT WS COL WS')
-    def visit_RESOURCE_NAME(self, node, children):
+    def visit_resource_name(self, node, children):
         """The name of a resource, to force a name of a resource.
 
         Without it, the resource entry name will be used.
@@ -300,7 +300,7 @@ class DataQLParser(FiltersParserMixin, BaseParser):
         return children[0]
 
     @rule('RESOURCE_NAME?')
-    def visit_OPTIONAL_RESOURCE_NAME(self, node, children):
+    def visit_optional_resource_name(self, node, children):
         """The optional name of a resource, to force a name of a resource if set.
 
         Without it, the resource entry name will be used.
@@ -330,7 +330,7 @@ class DataQLParser(FiltersParserMixin, BaseParser):
         return children[0] if children and children[0] else None
 
     @rule('FILTERS')
-    def visit_FIELD(self, node, children):
+    def visit_field(self, node, children):
         """A simple field.
 
         Arguments
@@ -410,7 +410,7 @@ class DataQLParser(FiltersParserMixin, BaseParser):
         return self.filters_to_resource(children[0], klass)
 
     @rule('FILTERS CUR_O CONTENT CUR_C')
-    def visit_OBJECT(self, node, children):
+    def visit_object(self, node, children):
         """Manage an object, represented by a ``.resources.Object`` instance.
 
         The first filter is removed to fill the name and args of the resource. See
@@ -440,7 +440,7 @@ class DataQLParser(FiltersParserMixin, BaseParser):
         return self.filters_to_resource(children[0], self.Object, resources=children[2])
 
     @rule('FILTERS BRA_O CONTENT BRA_C')
-    def visit_LIST(self, node, children):
+    def visit_list(self, node, children):
         """Manage a list, represented by a ``.resources.List`` instance.
 
         The first filter is removed to fill the name and args of the resource. See

--- a/dataql/parsers/mixins.py
+++ b/dataql/parsers/mixins.py
@@ -34,7 +34,7 @@ class NamedArgsParserMixin(BaseParser):
     >>> class TestParser(NamedArgsParserMixin, BaseParser):
     ...     default_rule = 'ROOT'
     ...     @rule('PAR_O NAMED_ARGS PAR_C')
-    ...     def visit_ROOT(self, node, children):
+    ...     def visit_root(self, node, children):
     ...         return 'Content with named args: %s' % children[1]
     ...
     >>> TestParser('(foo=TRUE, bar ="BAZ",quz=null)').data
@@ -45,7 +45,7 @@ class NamedArgsParserMixin(BaseParser):
     default_rule = 'NAMED_ARGS'
 
     @rule('NAMED_ARG NEXT_NAMED_ARGS')
-    def visit_NAMED_ARGS(self, node, children):
+    def visit_named_args(self, node, children):
         """Named arguments of a filter.
 
         Arguments
@@ -75,7 +75,7 @@ class NamedArgsParserMixin(BaseParser):
         return [children[0]] + (children[1] or [])
 
     @rule('COM NAMED_ARG')
-    def visit_NEXT_NAMED_ARG(self, node, children):
+    def visit_next_named_arg(self, node, children):
         """Named argument of a filter following a previous one (so, preceded by a comma).
 
         Arguments
@@ -109,7 +109,7 @@ class NamedArgsParserMixin(BaseParser):
         return children[1]
 
     @rule('NEXT_NAMED_ARG*')
-    def visit_NEXT_NAMED_ARGS(self, node, children):
+    def visit_next_named_args(self, node, children):
         """Named arguments of a filter following the first one.
 
         Arguments
@@ -141,7 +141,7 @@ class NamedArgsParserMixin(BaseParser):
         return children
 
     @rule('IDENT WS OPER WS VALUE')
-    def visit_NAMED_ARG(self, node, children):
+    def visit_named_arg(self, node, children):
         """Named argument of a filter.
 
         Arguments
@@ -203,7 +203,7 @@ class UnnamedArgsParserMixin(BaseParser):
     >>> class TestParser(UnnamedArgsParserMixin, BaseParser):
     ...     default_rule = 'ROOT'
     ...     @rule('PAR_O UNNAMED_ARGS PAR_C')
-    ...     def visit_ROOT(self, node, children):
+    ...     def visit_root(self, node, children):
     ...         return 'Content with unnamed args: %s' % children[1]
     ...
     >>> TestParser('(1,null, "foo")').data
@@ -214,7 +214,7 @@ class UnnamedArgsParserMixin(BaseParser):
     default_rule = 'UNNAMED_ARGS'
 
     @rule('UNNAMED_ARG NEXT_UNNAMED_ARGS')
-    def visit_UNNAMED_ARGS(self, node, children):
+    def visit_unnamed_args(self, node, children):
         """Unnamed arguments of a filter.
 
         Arguments
@@ -244,7 +244,7 @@ class UnnamedArgsParserMixin(BaseParser):
         return [children[0]] + (children[1] or [])
 
     @rule('COM UNNAMED_ARG')
-    def visit_NEXT_UNNAMED_ARG(self, node, children):
+    def visit_next_unnamed_arg(self, node, children):
         """Unnamed argument of a filter following a previous one (so, preceded by a comma).
 
         Arguments
@@ -278,7 +278,7 @@ class UnnamedArgsParserMixin(BaseParser):
         return children[1]
 
     @rule('NEXT_UNNAMED_ARG*')
-    def visit_NEXT_UNNAMED_ARGS(self, node, children):
+    def visit_next_unnamed_args(self, node, children):
         """Unnamed arguments of a filter following the first one.
 
         Arguments
@@ -309,7 +309,7 @@ class UnnamedArgsParserMixin(BaseParser):
         return children
 
     @rule('VALUE')
-    def visit_UNNAMED_ARG(self, node, children):
+    def visit_unnamed_arg(self, node, children):
         """Unnamed argument of a filter.
 
         Arguments
@@ -364,7 +364,7 @@ class ArgsParserMixin(NamedArgsParserMixin, UnnamedArgsParserMixin, BaseParser):
     >>> class TestParser(ArgsParserMixin, BaseParser):
     ...     default_rule = 'ROOT'
     ...     @rule('IDENT OPTIONAL_ARGS')
-    ...     def visit_ROOT(self, node, children):
+    ...     def visit_root(self, node, children):
     ...         return 'Ident "%s" with args: %s' % tuple(children)
     ...
     >>> TestParser('something(1,null, "foo")').data
@@ -375,7 +375,7 @@ class ArgsParserMixin(NamedArgsParserMixin, UnnamedArgsParserMixin, BaseParser):
     default_rule = 'OPTIONAL_ARGS'
 
     @rule('PAR_O OPTIONAL_ARGS_CONTENT PAR_C')
-    def visit_OPTIONAL_ARGS(self, node, children):
+    def visit_optional_args(self, node, children):
         """The optional arguments of a filter.
 
         Arguments
@@ -408,7 +408,7 @@ class ArgsParserMixin(NamedArgsParserMixin, UnnamedArgsParserMixin, BaseParser):
         return children[1]
 
     @rule('ARGS?')
-    def visit_OPTIONAL_ARGS_CONTENT(self, node, children):
+    def visit_optional_args_content(self, node, children):
         """The optional arguments of a filter (part inside the parentheses).
 
         Arguments
@@ -439,7 +439,7 @@ class ArgsParserMixin(NamedArgsParserMixin, UnnamedArgsParserMixin, BaseParser):
         return children[0] if children else []
 
     @rule('UNNAMED_ARGS_AND_NAMED_ARGS / UNNAMED_ARGS / NAMED_ARGS')
-    def visit_ARGS(self, node, children):
+    def visit_args(self, node, children):
         """Arguments of a filter (part inside the parentheses).
 
         The arguments of a filter can be named or not. But unnamed ones must always come first.
@@ -481,7 +481,7 @@ class ArgsParserMixin(NamedArgsParserMixin, UnnamedArgsParserMixin, BaseParser):
         return children[0]
 
     @rule('UNNAMED_ARGS COM NAMED_ARGS')
-    def visit_UNNAMED_ARGS_AND_NAMED_ARGS(self, node, children):
+    def visit_unnamed_args_and_named_args(self, node, children):
         """Unnamed arguments of a filter.
 
         Arguments
@@ -531,7 +531,7 @@ class FiltersParserMixin(ArgsParserMixin, BaseParser):
     >>> class TestParser(FiltersParserMixin, BaseParser):
     ...     default_rule = 'ROOT'
     ...     @rule('IDENT DOT FILTERS')
-    ...     def visit_ROOT(self, node, children):
+    ...     def visit_root(self, node, children):
     ...         return 'Ident "%s" filtered with %s' % (children[0], children[2])
     ...
     >>> TestParser('qux.foo().bar.baz(True, x=1)').data
@@ -542,7 +542,7 @@ class FiltersParserMixin(ArgsParserMixin, BaseParser):
     default_rule = 'FILTERS'
 
     @rule('FILTER NEXT_FILTERS')
-    def visit_FILTERS(self, node, children):
+    def visit_filters(self, node, children):
         """A succession of filters.
 
         Arguments
@@ -572,7 +572,7 @@ class FiltersParserMixin(ArgsParserMixin, BaseParser):
         return [children[0]] + (children[1] or [])
 
     @rule('IDENT FILTER_ARGS')
-    def visit_FILTER(self, node, children):
+    def visit_filter(self, node, children):
         """A filter, with optional arguments.
 
         Arguments
@@ -608,7 +608,7 @@ class FiltersParserMixin(ArgsParserMixin, BaseParser):
         )
 
     @rule('OPTIONAL_ARGS?')
-    def visit_FILTER_ARGS(self, node, children):
+    def visit_filter_args(self, node, children):
         """The optional arguments of a filter.
 
         Arguments
@@ -640,7 +640,7 @@ class FiltersParserMixin(ArgsParserMixin, BaseParser):
         return children[0] if children else None
 
     @rule('NEXT_FILTER*')
-    def visit_NEXT_FILTERS(self, node, children):
+    def visit_next_filters(self, node, children):
         """Optional filters following a first one.
 
         Arguments
@@ -669,7 +669,7 @@ class FiltersParserMixin(ArgsParserMixin, BaseParser):
         return children
 
     @rule('DOT FILTER')
-    def visit_NEXT_FILTER(self, node, children):
+    def visit_next_filter(self, node, children):
         """A filter that follow another one (so it starts with a dot).
 
         Arguments

--- a/dataql/parsers/mixins.py
+++ b/dataql/parsers/mixins.py
@@ -34,7 +34,7 @@ class NamedArgsParserMixin(BaseParser):
     >>> class TestParser(NamedArgsParserMixin, BaseParser):
     ...     default_rule = 'ROOT'
     ...     @rule('PAR_O NAMED_ARGS PAR_C')
-    ...     def visit_root(self, node, children):
+    ...     def visit_root(self, _, children):
     ...         return 'Content with named args: %s' % children[1]
     ...
     >>> TestParser('(foo=TRUE, bar ="BAZ",quz=null)').data
@@ -45,12 +45,12 @@ class NamedArgsParserMixin(BaseParser):
     default_rule = 'NAMED_ARGS'
 
     @rule('NAMED_ARG NEXT_NAMED_ARGS')
-    def visit_named_args(self, node, children):
+    def visit_named_args(self, _, children):
         """Named arguments of a filter.
 
         Arguments
         ---------
-        node : parsimonious.nodes.Node.
+        _ (node) : parsimonious.nodes.Node.
         children : list
             - 0: instance of ``.resources.NamedArg``, first named argument
             - 1: list of instances of ``.resources.NamedArg``, other named arguments
@@ -75,12 +75,12 @@ class NamedArgsParserMixin(BaseParser):
         return [children[0]] + (children[1] or [])
 
     @rule('COM NAMED_ARG')
-    def visit_next_named_arg(self, node, children):
+    def visit_next_named_arg(self, _, children):
         """Named argument of a filter following a previous one (so, preceded by a comma).
 
         Arguments
         ---------
-        node : parsimonious.nodes.Node.
+        _ (node) : parsimonious.nodes.Node.
         children : list
             - 0: for ``COM`` (comma): ``None``.
             - 1: for ``NAMED_ARG``: instance of ``.resources.NamedArg``.
@@ -109,12 +109,12 @@ class NamedArgsParserMixin(BaseParser):
         return children[1]
 
     @rule('NEXT_NAMED_ARG*')
-    def visit_next_named_args(self, node, children):
+    def visit_next_named_args(self, _, children):
         """Named arguments of a filter following the first one.
 
         Arguments
         ---------
-        node : parsimonious.nodes.Node.
+        _ (node) : parsimonious.nodes.Node.
         children : list
             - 1: list of instances of ``.resources.NamedArg``.
 
@@ -141,12 +141,12 @@ class NamedArgsParserMixin(BaseParser):
         return children
 
     @rule('IDENT WS OPER WS VALUE')
-    def visit_named_arg(self, node, children):
+    def visit_named_arg(self, _, children):
         """Named argument of a filter.
 
         Arguments
         ---------
-        node : parsimonious.nodes.Node.
+        _ (node) : parsimonious.nodes.Node.
         children : list
             - 0: name of the arg
             - 1: for ``WS`` (whitespace): ``None``.
@@ -203,7 +203,7 @@ class UnnamedArgsParserMixin(BaseParser):
     >>> class TestParser(UnnamedArgsParserMixin, BaseParser):
     ...     default_rule = 'ROOT'
     ...     @rule('PAR_O UNNAMED_ARGS PAR_C')
-    ...     def visit_root(self, node, children):
+    ...     def visit_root(self, _, children):
     ...         return 'Content with unnamed args: %s' % children[1]
     ...
     >>> TestParser('(1,null, "foo")').data
@@ -214,12 +214,12 @@ class UnnamedArgsParserMixin(BaseParser):
     default_rule = 'UNNAMED_ARGS'
 
     @rule('UNNAMED_ARG NEXT_UNNAMED_ARGS')
-    def visit_unnamed_args(self, node, children):
+    def visit_unnamed_args(self, _, children):
         """Unnamed arguments of a filter.
 
         Arguments
         ---------
-        node : parsimonious.nodes.Node.
+        _ (node) : parsimonious.nodes.Node.
         children : list
             - 0: instance of ``.resources.PosArg``, first unnamed argument
             - 1: list of instances of ``.resources.PosArg``, other unnamed arguments
@@ -244,12 +244,12 @@ class UnnamedArgsParserMixin(BaseParser):
         return [children[0]] + (children[1] or [])
 
     @rule('COM UNNAMED_ARG')
-    def visit_next_unnamed_arg(self, node, children):
+    def visit_next_unnamed_arg(self, _, children):
         """Unnamed argument of a filter following a previous one (so, preceded by a comma).
 
         Arguments
         ---------
-        node : parsimonious.nodes.Node.
+        _ (node) : parsimonious.nodes.Node.
         children : list
             - 0: for ``COM`` (comma): ``None``.
             - 1: for ``UNNAMED_ARG``: instance of ``.resources.PosArg``.
@@ -278,12 +278,12 @@ class UnnamedArgsParserMixin(BaseParser):
         return children[1]
 
     @rule('NEXT_UNNAMED_ARG*')
-    def visit_next_unnamed_args(self, node, children):
+    def visit_next_unnamed_args(self, _, children):
         """Unnamed arguments of a filter following the first one.
 
         Arguments
         ---------
-        node : parsimonious.nodes.Node.
+        _ (node) : parsimonious.nodes.Node.
         children : list
             - 1: list of instances of ``.resources.PosArg``.
 
@@ -309,12 +309,12 @@ class UnnamedArgsParserMixin(BaseParser):
         return children
 
     @rule('VALUE')
-    def visit_unnamed_arg(self, node, children):
+    def visit_unnamed_arg(self, _, children):
         """Unnamed argument of a filter.
 
         Arguments
         ---------
-        node : parsimonious.nodes.Node.
+        _ (node) : parsimonious.nodes.Node.
         children : list
             - 0: value of the unnamed arg
 
@@ -364,7 +364,7 @@ class ArgsParserMixin(NamedArgsParserMixin, UnnamedArgsParserMixin, BaseParser):
     >>> class TestParser(ArgsParserMixin, BaseParser):
     ...     default_rule = 'ROOT'
     ...     @rule('IDENT OPTIONAL_ARGS')
-    ...     def visit_root(self, node, children):
+    ...     def visit_root(self, _, children):
     ...         return 'Ident "%s" with args: %s' % tuple(children)
     ...
     >>> TestParser('something(1,null, "foo")').data
@@ -375,12 +375,12 @@ class ArgsParserMixin(NamedArgsParserMixin, UnnamedArgsParserMixin, BaseParser):
     default_rule = 'OPTIONAL_ARGS'
 
     @rule('PAR_O OPTIONAL_ARGS_CONTENT PAR_C')
-    def visit_optional_args(self, node, children):
+    def visit_optional_args(self, _, children):
         """The optional arguments of a filter.
 
         Arguments
         ---------
-        node : parsimonious.nodes.Node.
+        _ (node) : parsimonious.nodes.Node.
         children : list
             - 0: for ``PAR_O`` (opening parenthesis): ``None``.
             - 1: list of instances of subclasses of ``.resources.Arg``.
@@ -408,12 +408,12 @@ class ArgsParserMixin(NamedArgsParserMixin, UnnamedArgsParserMixin, BaseParser):
         return children[1]
 
     @rule('ARGS?')
-    def visit_optional_args_content(self, node, children):
+    def visit_optional_args_content(self, _, children):
         """The optional arguments of a filter (part inside the parentheses).
 
         Arguments
         ---------
-        node : parsimonious.nodes.Node.
+        _ (node) : parsimonious.nodes.Node.
         children : list
             - 1: list of instances of ``.resources.NamedArg`` or subclasses.
 
@@ -438,8 +438,8 @@ class ArgsParserMixin(NamedArgsParserMixin, UnnamedArgsParserMixin, BaseParser):
 
         return children[0] if children else []
 
-    @rule('UNNAMED_ARGS_AND_NAMED_ARGS / UNNAMED_ARGS / NAMED_ARGS')
-    def visit_args(self, node, children):
+    @rule('ALL_ARGS / UNNAMED_ARGS / NAMED_ARGS')
+    def visit_args(self, _, children):
         """Arguments of a filter (part inside the parentheses).
 
         The arguments of a filter can be named or not. But unnamed ones must always come first.
@@ -451,7 +451,7 @@ class ArgsParserMixin(NamedArgsParserMixin, UnnamedArgsParserMixin, BaseParser):
 
         Arguments
         ---------
-        node : parsimonious.nodes.Node.
+        _ (node) : parsimonious.nodes.Node.
         children : list
             - 0: list of instances of ``.resources.NamedArg`` or subclasses.
 
@@ -481,12 +481,12 @@ class ArgsParserMixin(NamedArgsParserMixin, UnnamedArgsParserMixin, BaseParser):
         return children[0]
 
     @rule('UNNAMED_ARGS COM NAMED_ARGS')
-    def visit_unnamed_args_and_named_args(self, node, children):
-        """Unnamed arguments of a filter.
+    def visit_all_args(self, _, children):
+        """Unnamed and named arguments of a filter.
 
         Arguments
         ---------
-        node : parsimonious.nodes.Node.
+        _ (node) : parsimonious.nodes.Node.
         children : list
             - o: list of instances of ``.resources.PosArg``.
             - 1: list of instances of ``.resources.NamedArg``.
@@ -499,10 +499,9 @@ class ArgsParserMixin(NamedArgsParserMixin, UnnamedArgsParserMixin, BaseParser):
         Example
         -------
 
-        >>> ArgsParserMixin(r'1, foo="bar"', default_rule='UNNAMED_ARGS_AND_NAMED_ARGS').data
+        >>> ArgsParserMixin(r'1, foo="bar"', default_rule='ALL_ARGS').data
         [1, foo="bar"]
-        >>> ArgsParserMixin(r'1, 2,foo="bar", bar="qux"',
-        ... default_rule='UNNAMED_ARGS_AND_NAMED_ARGS').data
+        >>> ArgsParserMixin(r'1, 2,foo="bar", bar="qux"', default_rule='ALL_ARGS').data
         [1, 2, foo="bar", bar="qux"]
 
         """
@@ -531,7 +530,7 @@ class FiltersParserMixin(ArgsParserMixin, BaseParser):
     >>> class TestParser(FiltersParserMixin, BaseParser):
     ...     default_rule = 'ROOT'
     ...     @rule('IDENT DOT FILTERS')
-    ...     def visit_root(self, node, children):
+    ...     def visit_root(self, _, children):
     ...         return 'Ident "%s" filtered with %s' % (children[0], children[2])
     ...
     >>> TestParser('qux.foo().bar.baz(True, x=1)').data
@@ -542,12 +541,12 @@ class FiltersParserMixin(ArgsParserMixin, BaseParser):
     default_rule = 'FILTERS'
 
     @rule('FILTER NEXT_FILTERS')
-    def visit_filters(self, node, children):
+    def visit_filters(self, _, children):
         """A succession of filters.
 
         Arguments
         ---------
-        node : parsimonious.nodes.Node.
+        _ (node) : parsimonious.nodes.Node.
         children : list
             - 0: instance of ``.resources.Filter``, the first filter
             - 1: list of instances of ``.resources.Filter``, the other filters
@@ -572,12 +571,12 @@ class FiltersParserMixin(ArgsParserMixin, BaseParser):
         return [children[0]] + (children[1] or [])
 
     @rule('IDENT FILTER_ARGS')
-    def visit_filter(self, node, children):
+    def visit_filter(self, _, children):
         """A filter, with optional arguments.
 
         Arguments
         ---------
-        node : parsimonious.nodes.Node.
+        _ (node) : parsimonious.nodes.Node.
         children : list
             - 0: string, name of the filter.
             - 1: list of instances of ``.resources.NamedArg``
@@ -608,12 +607,12 @@ class FiltersParserMixin(ArgsParserMixin, BaseParser):
         )
 
     @rule('OPTIONAL_ARGS?')
-    def visit_filter_args(self, node, children):
+    def visit_filter_args(self, _, children):
         """The optional arguments of a filter.
 
         Arguments
         ---------
-        node : parsimonious.nodes.Node.
+        _ (node) : parsimonious.nodes.Node.
         children : list
             - 0: list of instances of ``.resources.NamedArg`` or subclasses,  or None
 
@@ -640,12 +639,12 @@ class FiltersParserMixin(ArgsParserMixin, BaseParser):
         return children[0] if children else None
 
     @rule('NEXT_FILTER*')
-    def visit_next_filters(self, node, children):
+    def visit_next_filters(self, _, children):
         """Optional filters following a first one.
 
         Arguments
         ---------
-        node : parsimonious.nodes.Node.
+        _ (node) : parsimonious.nodes.Node.
         children : list
             - 0: list of instances of ``.resources.Filter``
 
@@ -669,12 +668,12 @@ class FiltersParserMixin(ArgsParserMixin, BaseParser):
         return children
 
     @rule('DOT FILTER')
-    def visit_next_filter(self, node, children):
+    def visit_next_filter(self, _, children):
         """A filter that follow another one (so it starts with a dot).
 
         Arguments
         ---------
-        node : parsimonious.nodes.Node.
+        _ (node) : parsimonious.nodes.Node.
         children : list
             - 0: for ``DOT`` (a dot): ``None``.
             - 1: instance of ``.resources.Filter``

--- a/dataql/parsers/mixins.py
+++ b/dataql/parsers/mixins.py
@@ -9,10 +9,12 @@ It provides some mixin to ease the creation of complex parsers:
 
 """
 
+from abc import ABCMeta
+
 from dataql.parsers.base import BaseParser, rule
 
 
-class NamedArgsParserMixin(BaseParser):
+class NamedArgsParserMixin(BaseParser, metaclass=ABCMeta):
     """Parser mixin that provides rules to manage named arguments.
 
     A list of named arguments is a list of at least one named argument separated by a comma.
@@ -182,7 +184,7 @@ class NamedArgsParserMixin(BaseParser):
         )
 
 
-class UnnamedArgsParserMixin(BaseParser):
+class UnnamedArgsParserMixin(BaseParser, metaclass=ABCMeta):
     """Parser mixin that provides rules to manage unnamed arguments.
 
     A list of unnamed arguments is a list of at least one unnamed argument separated by a comma.
@@ -344,7 +346,8 @@ class UnnamedArgsParserMixin(BaseParser):
         )
 
 
-class ArgsParserMixin(NamedArgsParserMixin, UnnamedArgsParserMixin, BaseParser):
+class ArgsParserMixin(NamedArgsParserMixin, UnnamedArgsParserMixin, BaseParser,
+                      metaclass=ABCMeta):
     """Parser mixin that provides rules to manage arguments in parentheses.
 
     To use it, add this mixin to the class bases, and use``OPTIONAL_ARGS`` in your rule(s).
@@ -509,7 +512,7 @@ class ArgsParserMixin(NamedArgsParserMixin, UnnamedArgsParserMixin, BaseParser):
         return children[0] + children[2]
 
 
-class FiltersParserMixin(ArgsParserMixin, BaseParser):
+class FiltersParserMixin(ArgsParserMixin, BaseParser, metaclass=ABCMeta):
     """Parser mixin that provides rules to manage arguments in parentheses.
 
     To use it, add this mixin to the class bases, and use``OPTIONAL_ARGS`` in your rule(s).

--- a/dataql/resources.py
+++ b/dataql/resources.py
@@ -35,8 +35,10 @@ To use subclasses of the classes defined here, they must be set on the parser:
 
 __all__ = ('Field', 'List', 'Object', 'Filter', 'NamedArg', 'PosArg')
 
+from abc import ABCMeta
 
-class WithArgsMixin:
+
+class WithArgsMixin(metaclass=ABCMeta):
     """Mixin to manage entities accepting arguments.
 
     Attributes
@@ -84,7 +86,7 @@ class WithArgsMixin:
         return args, kwargs
 
 
-class Resource(WithArgsMixin):
+class Resource(WithArgsMixin, metaclass=ABCMeta):
     """Base class for all resource classes.
 
     A resource is mainly a attribute to retrieve from a value (via a solver).
@@ -214,7 +216,7 @@ class Field(Resource):
     pass
 
 
-class MultiResources(Resource):
+class MultiResources(Resource, metaclass=ABCMeta):
     """Base class for multi resources: get many attributes for one resource.
 
     It simply add a ``resources`` attributes to the base ``Resource`` class.
@@ -292,9 +294,11 @@ class MultiResources(Resource):
         parent_repr = super().__repr__()
 
         if self.resources:
-            return ('%(start)s\n'
-                    '%(sub)s\n'
-                    '%(indent)s</%(cls)s[%(entry_name)s]>') % {
+            return (
+                '%(start)s\n'
+                '%(sub)s\n'
+                '%(indent)s</%(cls)s[%(entry_name)s]>'
+            ) % {
                 'start': parent_repr[:-3] + '>',
                 'sub': '\n'.join(map(str, self.resources)),
                 'cls': self.__class__.__name__,

--- a/dataql/solvers/exceptions.py
+++ b/dataql/solvers/exceptions.py
@@ -4,9 +4,11 @@ It holds all the exception that may be raised by this module.
 
 """
 
-from dataql.utils import class_repr
+from abc import ABCMeta
 
 from dataql.exceptions import DataQLException
+from dataql.utils import class_repr
+
 
 __all__ = (
     'AlreadyRegistered',
@@ -22,12 +24,12 @@ __all__ = (
 )
 
 
-class SolversException(DataQLException):
+class SolversException(DataQLException, metaclass=ABCMeta):
     """Base for exceptions raised in the ``dataql.solvers`` module."""
     pass
 
 
-class SolverObjectException(SolversException):
+class SolverObjectException(SolversException, metaclass=ABCMeta):
     """Base for exceptions raised by a ``Solver`` object."""
     pass
 
@@ -52,6 +54,7 @@ class CannotSolve(SolverObjectException):
         self.solver = solver
         self.resource = resource
         self.value = value
+        super().__init__(str(self))
 
     def __str__(self):
         return 'Solver `%s` was not able to solve resource `%s`.' % (
@@ -60,17 +63,17 @@ class CannotSolve(SolverObjectException):
         )
 
 
-class AttributeSolverException(SolverObjectException):
+class AttributeSolverException(SolverObjectException, metaclass=ABCMeta):
     """Base for exceptions raised by a ``AttributeSolver`` object."""
     pass
 
 
-class ObjectSolverException(SolverObjectException):
+class ObjectSolverException(SolverObjectException, metaclass=ABCMeta):
     """Base for exceptions raised by a ``ObjectSolver`` object."""
     pass
 
 
-class ListSolverException(SolverObjectException):
+class ListSolverException(SolverObjectException, metaclass=ABCMeta):
     """Base for exceptions raised by a ``ListSolver`` object."""
     pass
 
@@ -93,6 +96,7 @@ class NotIterable(ListSolverException):
     def __init__(self, resource, source):
         self.resource = resource
         self.source = source
+        super().__init__(str(self))
 
     def __str__(self):
         return '`%s` from source `%s` is not iterable' % (
@@ -101,7 +105,7 @@ class NotIterable(ListSolverException):
         )
 
 
-class AttributeException(SolversException):
+class AttributeException(SolversException, metaclass=ABCMeta):
     """Base for exceptions raised by an ``Attribute`` or ``Attributes`` object."""
     pass
 
@@ -124,6 +128,7 @@ class AttributeNotFound(AttributeException, KeyError):
     def __init__(self, name, source=None):
         self.name = name
         self.source = source
+        super().__init__(str(self))
 
     def __str__(self):
         if self.source:
@@ -164,6 +169,7 @@ class CallableError(AttributeException):
         self.call_args = args
         self.call_kwargs = kwargs
         self.original_exception = original_exception
+        super().__init__(str(self))
 
     def __str__(self):
         return 'An error occurred while calling `%s` (%s arguments)' % (
@@ -172,7 +178,7 @@ class CallableError(AttributeException):
         )
 
 
-class SourceException(SolversException):
+class SourceException(SolversException, metaclass=ABCMeta):
     """Base for exceptions raised by a ``Source`` object."""
     pass
 
@@ -191,6 +197,7 @@ class InvalidSource(SourceException):
 
     def __init__(self, source):
         self.source = source
+        super().__init__(str(self))
 
     def __str__(self):
         return '%s cannot be used as a source, it must be a class' % (
@@ -216,6 +223,7 @@ class NotSolvable(SourceException):
     def __init__(self, source, value):
         self.source = source
         self.value = value
+        super().__init__(str(self))
 
     def __str__(self):
         if self.source.allow_class:
@@ -228,7 +236,7 @@ class NotSolvable(SourceException):
             )
 
 
-class RegistryException(SolversException):
+class RegistryException(SolversException, metaclass=ABCMeta):
     """Base for exceptions raised by a ``Registry`` object."""
     pass
 
@@ -250,6 +258,7 @@ class AlreadyRegistered(RegistryException):
     def __init__(self, registry, source):
         self.registry = registry
         self.source = source
+        super().__init__(str(self))
 
     def __str__(self):
         return 'The `%s` source is already in the registry.' % (
@@ -274,6 +283,7 @@ class SourceNotFound(RegistryException, KeyError):
     def __init__(self, registry, source):
         self.registry = registry
         self.source = source
+        super().__init__(str(self))
 
     def __str__(self):
         return 'The `%s` source is not in the registry.' % (
@@ -296,6 +306,7 @@ class SolverNotFound(RegistryException):
     def __init__(self, registry, resource):
         self.registry = registry
         self.resource = resource
+        super().__init__(str(self))
 
     def __str__(self):
         return 'No solvers found for this kind of resource: `%s`' % (
@@ -323,6 +334,7 @@ class SolveFailure(RegistryException):
         self.registry = registry
         self.resource = resource
         self.value = value
+        super().__init__(str(self))
 
     def __str__(self):
         return 'Unable to solve resource `%s`.' % (

--- a/dataql/utils.py
+++ b/dataql/utils.py
@@ -29,29 +29,3 @@ def class_repr(value):
     if not isinstance(value, type):
         klass = klass.__class__
     return '.'.join([klass.__module__, klass.__name__])
-
-
-def isclass(value):
-    """Tell if the value is a class or not.
-
-    Arguments
-    ---------
-    value
-        Value to test if its a class or not.
-
-    Returns
-    -------
-    boolean
-        ``True`` if the value is a class, ``False`` otherwise.
-
-    Example
-    -------
-
-    >>> from datetime import date
-    >>> isclass(date)
-    True
-    >>> isclass(date.today())
-    False
-
-    """
-    return isinstance(value, type)

--- a/pylintrc
+++ b/pylintrc
@@ -1,0 +1,390 @@
+[MASTER]
+
+# Specify a configuration file.
+#rcfile=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Profiled execution.
+profile=no
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Deprecated. It was used to include message's id in output. Use --msg-template
+# instead.
+include-ids=no
+
+# Deprecated. It was used to include symbolic ids of messages in output. Use
+# --msg-template instead.
+symbols=no
+
+# Use multiple processes to speed up Pylint.
+jobs=1
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-whitelist=
+
+# Allow optimization of some AST trees. This will activate a peephole AST
+# optimizer, which will apply various small optimizations. For instance, it can
+# be used to obtain the result of joining multiple strings with the addition
+# operator. Joining a lot of strings can lead to a maximum recursion error in
+# Pylint and this flag can prevent that. It has one side effect, the resulting
+# AST will be different than the one from reality.
+optimize-ast=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time. See also the "--disable" option for examples.
+#enable=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+disable=W1624,E1608,E1606,R0903,W1616,E1607,C0302,E1604,E1602,W1636,W1638,W1606,W1603,W1615,W0704,I0021,E1603,W1609,W1634,R0913,W1632,W1604,W1602,W1640,R0201,W1622,E1601,W1635,W1607,W1626,W1612,W1617,W1628,I0020,W1613,W1621,W1618,W1610,W1629,W1637,W1633,W1608,W1605,W1639,W1630,W1625,W1611,W1623,W1619,W1627,W1614,W0141,W1620,E1605,W1601
+
+
+[REPORTS]
+
+# Set the output format. Available formats are text, parseable, colorized, msvs
+# (visual studio) and html. You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Put messages in a separate file for each module / package specified on the
+# command line instead of printing them on stdout. Reports (if any) will be
+# written in a file name "pylint_global.[txt|html]".
+files-output=no
+
+# Tells whether to display a full report or only the messages
+reports=yes
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Add a comment according to your evaluation note. This is used by the global
+# evaluation report (RP0004).
+comment=no
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template=
+
+
+[VARIABLES]
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=_$|dummy
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,_cb
+
+
+[SPELLING]
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[FORMAT]
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+# List of optional constructs for which whitespace checking is disabled
+no-space-check=trailing-comma,dict-separator
+
+# Maximum number of lines in a module
+max-module-lines=1000
+
+# String used as indentation unit. This is usually " " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+
+[BASIC]
+
+# Required attributes for module, separated by a comma
+required-attributes=
+
+# List of builtins function names that should not be used, separated by a comma
+bad-functions=map,filter
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,j,k,ex,Run,_
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,bar,baz,toto,tutu,tata
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# Regular expression matching correct class names
+class-rgx=[A-Z_][a-zA-Z0-9]+$
+
+# Naming hint for class names
+class-name-hint=[A-Z_][a-zA-Z0-9]+$
+
+# Regular expression matching correct inline iteration names
+inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
+
+# Naming hint for inline iteration names
+inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
+
+# Regular expression matching correct attribute names
+attr-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for attribute names
+attr-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct method names
+method-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for method names
+method-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct constant names
+const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Naming hint for constant names
+const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Regular expression matching correct variable names
+variable-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for variable names
+variable-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct function names
+function-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for function names
+function-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct class attribute names
+class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Naming hint for class attribute names
+class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Regular expression matching correct module names
+module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Naming hint for module names
+module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Regular expression matching correct argument names
+argument-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for argument names
+argument-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=__.*__
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+
+[SIMILARITIES]
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging
+
+
+[TYPECHECK]
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis
+ignored-modules=
+
+# List of classes names for which member attributes should not be checked
+# (useful for classes with attributes dynamically set).
+ignored-classes=SQLObject
+
+# When zope mode is activated, add a predefined set of Zope acquired attributes
+# to generated-members.
+zope=no
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E0201 when accessed. Python regular
+# expressions are accepted.
+generated-members=REQUEST,acl_users,aq_parent
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,XXX,TODO
+
+
+[CLASSES]
+
+# List of interface methods to ignore, separated by a comma. This is used for
+# instance to not check methods defines in Zope's Interface base class.
+ignore-iface-methods=isImplementedBy,deferred,extends,names,namesAndDescriptions,queryDescriptionFor,getBases,getDescriptionFor,getDoc,getName,getTaggedValue,getTaggedValueTags,isEqualOrExtendedBy,setTaggedValue,isImplementedByInstancesOf,adaptWith,is_implemented_by
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,__new__,setUp
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,_fields,_replace,_source,_make
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=5
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*
+
+# Maximum number of locals for function / method body
+max-locals=15
+
+# Maximum number of return / yield for function / method body
+max-returns=6
+
+# Maximum number of branch for function / method body
+max-branches=12
+
+# Maximum number of statements in function / method body
+max-statements=50
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+
+[IMPORTS]
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=stringprep,optparse
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=Exception

--- a/run_tests.py
+++ b/run_tests.py
@@ -72,7 +72,7 @@ def discover(start_directory, top_directory=None):
     for module in walk_modules(top_directory):
         try:
             tests = doctest.DocTestSuite(module)
-        except ValueError as e:
+        except ValueError:
             pass
         else:
             suite.addTest(tests)


### PR DESCRIPTION
- force rules to be uppercase but functions to be `visit_*` in lowercase
- manage unused arguments in `visit_*` rules
- use `ABCMeta` from `abc` module to defined abstract classes
- lot of pylint adjustements
- add a `pylintrc` file disabling these rules:
  - too-many-arguments
  - too-few-public-methods
  - bad-builtin
  - too-many-lines
  - no-self-use
  - too-many-ancestors
