### PR TITLE
Better parser exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [PEP 440 about versioning](https://www.python.org/dev/pe
 - Better management of instances of objects with a `__call__` method.
 - Add a `run_tests.py` file.
 - Allow using spaces around colon when naming a resource in a query.
+- Better exceptions
 
 ## [0.0.1a1] - 2015-06-15
 - First working version

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ You may refer to the [example.py](example.py) file for usage.
 
 This prototype is working as expected, but there is a lot of things to do:
 
-- create subclasses for exceptions
+- ~~create subclasses for exceptions~~
 - write documentation about how to use `dataql` to get data from a query
 - write documentation about how to create its own parser
 - test on the the Django ORM (it should work)

--- a/dataql/parsers/exceptions.py
+++ b/dataql/parsers/exceptions.py
@@ -1,0 +1,41 @@
+"""``exceptions`` module of ``dataql.parsers``.
+
+It holds all the exception that may be raised by this module.
+
+"""
+
+from dataql.exceptions import DataQLException
+
+
+class ParserError(DataQLException):
+    """Exception raised when the parser failed to parse a query.
+
+    It is raised when a ``parsimonious.exceptions.ParseError`` is raised, to provide
+    a more friendly message, keeping the original exception as attribute.
+
+    This exception string only exposes line and column of the error with a abstract
+    from the query starting at the position the error occurred.
+
+    Attributes
+    ----------
+    original_exception : parsimonious.exceptions.ParseError
+        The original exception, with everything needed for the display: text, position...
+
+    """
+
+    def __init__(self, original_exception):
+        self.original_exception = original_exception
+
+        super().__init__(str(self))
+
+    def __str__(self):
+        pos = self.original_exception.pos
+
+        return (
+            'Problem with parsing at line %s, column %s. The non-matching portion of '
+            'the text begins with: "%s"'
+        ) % (
+            self.original_exception.line(),
+            self.original_exception.column(),
+            self.original_exception.text[pos:pos + 20],
+        )

--- a/dataql/solvers/exceptions.py
+++ b/dataql/solvers/exceptions.py
@@ -37,7 +37,7 @@ class SolverObjectException(SolversException, metaclass=ABCMeta):
 class CannotSolve(SolverObjectException):
     """Exception raised when a solver accepts to solve a resource but is not able to do it.
 
-    This exception string expose the name and class of the solver and the resource.
+    This exception string exposes the name and class of the solver and the resource.
 
     Attributes
     ---------
@@ -317,7 +317,7 @@ class SolverNotFound(RegistryException):
 class SolveFailure(RegistryException):
     """Exception raised when no solver was able to solve a (resource, value) couple.
 
-    This exception string expose the name and class of the solver and the resource.
+    This exception string exposes the name and class of the solver and the resource.
 
     Attributes
     ---------


### PR DESCRIPTION
Add a new `dataql.parsers.exceptions.ParserError` exception that is raised when the parser failed.

Try to give a better position where the error occurred than parsimonious by trying with a `DebugDataQLParser` created just for this.
