### PR TITLE
List resources accepts more kind of resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [PEP 440 about versioning](https://www.python.org/dev/pe
 - Allow using spaces around colon when naming a resource in a query.
 - Better exceptions
 - Manage slicing/list indexing in filters
+- Change in the format for lists, allowing to return list of values, not only list of dicts
 
 ## [0.0.1a1] - 2015-06-15
 - First working version

--- a/README.md
+++ b/README.md
@@ -21,10 +21,12 @@ with this example query:
 User.get('Elon Musk') {
     name,
     birthday.strftime('%x'),
-    companies[
+    companies[{
         name,
-        date:created_year,
-    ]
+        year:created_year,
+    }],
+    company_names: companies[name],
+    first_company:companies.0.name,
 }
 ```
 
@@ -37,13 +39,15 @@ And to get data like that:
     'companies': [
         {
             'name': 'Paypal',
-            'date': 1999
+            'year': 1999
         },
         {
             'name': 'Space X',
-            'date': 2002
+            'year': 2002
         }
-    ]
+    ],
+    'company_names': ['Paypal', 'Space X'],
+    'first_company': 'Paypal',
 }
 ```
 
@@ -103,7 +107,7 @@ This prototype is working as expected, but there is a lot of things to do:
 - create an advanced solver for Django (using `select_related` and `prefetch_related`)
 - ~~allow the use of filters that are not attributes of instances, but simple functions~~
 - allow the retrieval of ~~list entries~~ or dict entries, not only instance attributes
-- allow returning lists of values, not only objects
+- ~~allow returning lists of values, not only objects~~
 - tell me
 
 ## Tests

--- a/dataql/resources.py
+++ b/dataql/resources.py
@@ -89,7 +89,7 @@ class Resource(metaclass=ABCMeta):
 
         self.parent = None
 
-        if not self.filters:
+        if not self.filters and self.name:
             self.filters = [Filter(name=self.name)]
 
         for filter_ in self.filters:
@@ -120,12 +120,13 @@ class Resource(metaclass=ABCMeta):
         """
 
         filters = ''
-        if len(self.filters) > 1 or self.filters[0].name != self.name or self.filters[0].args:
+        if len(self.filters) > 1 or self.filters and (
+                self.filters[0].name != self.name or self.filters[0].args):
             filters = ' ' + ''.join(map(str, self.filters))
 
-        result = '%(indent)s<%(cls)s[%(name)s]%(filters)s />' % {
+        result = '%(indent)s<%(cls)s%(name)s%(filters)s />' % {
             'cls': self.__class__.__name__,
-            'name': '%s' % self.name,
+            'name': ('[%s]' % self.name) if self.name else '',
             'filters': filters,
             'indent': '  ' * self.get_level(),
         }
@@ -231,12 +232,12 @@ class MultiResources(Resource, metaclass=ABCMeta):
             return (
                 '%(start)s\n'
                 '%(sub)s\n'
-                '%(indent)s</%(cls)s[%(name)s]>'
+                '%(indent)s</%(cls)s%(name)s>'
             ) % {
                 'start': parent_repr[:-3] + '>',
                 'sub': '\n'.join(map(str, self.resources)),
                 'cls': self.__class__.__name__,
-                'name': self.name,
+                'name': ('[%s]' % self.name) if self.name else '',
                 'indent': '  ' * self.get_level(),
             }
         else:

--- a/example.py
+++ b/example.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 from datetime import datetime, date
 
 from dataql.parsers import DataQLParser
@@ -56,10 +58,11 @@ query = r'''
 User.get('Elon Musk') {
     name,
     birthday.strftime('%x'),
-    companies[
+    companies[{
         name,
-        date:created_year,
-    ],
+        year:created_year,
+    }],
+    company_names: companies[name],
     first_company:companies.0.name,
 }
 '''
@@ -72,7 +75,6 @@ result = registry.solve_resource(
     DataQLParser(query).data
 )
 
-
 # Compare!
 assert result == {
     'name': 'Elon Musk',
@@ -80,12 +82,13 @@ assert result == {
     'companies': [
         {
             'name': 'Paypal',
-            'date': 1999
+            'year': 1999
         },
         {
             'name': 'Space X',
-            'date': 2002
+            'year': 2002
         }
     ],
+    'company_names': ['Paypal', 'Space X'],
     'first_company': 'Paypal',
 }


### PR DESCRIPTION
It can now accepts one or many resources and behave like this:
- if only one resource, return a list with the result of this resource
  for each iteration of the value
- if more that one resource, return a list with, for each iteration, a
  list of each subresource for the value

This means that this breaks compatibility:

Previously, `[foo, bar]` returned a list of dict with two keys, `foo`,
and `bar`.

Not it returns a list of list, each sublist having the value for `foo`
and `bar`.

To have the same behavior as before, you should write `[{foo, bar}]`.

This allows to reuse the concept of fields and objects and adds the
possibility to return list of things, not only list of dicts.
