### PR TITLE
Add ability to access dict entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [PEP 440 about versioning](https://www.python.org/dev/pe
 - Better exceptions
 - Manage slicing/list indexing in filters
 - Change in the format for lists, allowing to return list of values, not only list of dicts
+- Access allowed dict items
 
 ## [0.0.1a1] - 2015-06-15
 - First working version

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ This prototype is working as expected, but there is a lot of things to do:
 - test on the the Django ORM (it should work)
 - create an advanced solver for Django (using `select_related` and `prefetch_related`)
 - ~~allow the use of filters that are not attributes of instances, but simple functions~~
-- allow the retrieval of ~~list entries~~ or dict entries, not only instance attributes
+- ~~allow the retrieval of list entries or dict entries, not only instance attributes~~
 - ~~allow returning lists of values, not only objects~~
 - tell me
 


### PR DESCRIPTION
This works this way:

The solver starts by trying to access the name as an attribute.
If an `AttributeError` exception is raised, then it tries to access it
via a dict-like approach.
If it still fail via a `KeyError` exception, then a
`AttributeNotFound` excetption is raised.

The key must of course be one of the attribute allowed for the class.

Their is no way to specify keys to retrieve for a simple dict. If the
`dict` class is added as a source to the registry allowing all
attributes, then all keys will be allowed for all dicts (if the dict class is not registered as a source, no key will be available for simple dicts)

It still possible, though, to use a function at the upper level that
will act as an attribute and will return only some keys we want.

If we have this:

``` python
class Klass:
    def func(self):
        return {'foo': 0, 'bar': 1, 'baz': 2}

registry.register(dict)
registry.register(Klass)
```

Then the user will be able to access `func`, then `foo` `bar` and `baz`
from the dict.

If we don't want the user to access `baz` without modifying the class,
we can do this:

``` python
def func(obj):
    d = obj.func()
    allowed = {'foo', 'bar'}
    return {k: v for k, v in d.items() if k in allowed}

registry.register(dict)
registry.register(klass, ('func', func))
```

Then, when solving the `func` attribute, it's the `func` function what
will be called, itself calling the method then returning a dict with
only the wanted keys

Another way to do it is:

``` python
class FuncDict(dict): pass

def func(obj):
    return FuncDict(obj.func())

registry.register(FuncDict, ['foo', 'bar'])
registry.register(klass, ('func', func))
```
